### PR TITLE
*[style]: Fixed github linguist errs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ts linguistic_language=TypeScript


### PR DESCRIPTION
Fixed github linguist errs
===================


Whenever github linguist finds a shebang in a .ts file, it takes it as a .js file
This fixed the github misinterpretation.