### PR TITLE
fix: redefined search fn return from `string[]` type to `JSON[]`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,9 @@
+import search from "./src/lib/search";
+
+/**
+ *  Full text search algorithm
+ *  ----
+ *  By [@pacifiquem](https://github.com/pacifiquem) and [@regisrex](https://github.com/regisrex)
+ */
+
+export default search;

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,11 +1,11 @@
 import { ParsedJSON } from "../interfaces/json.interface";
 import parser from "./parser";
 
-export default function search(query: string, jsonArray: any[]) {
+export default function search(query: string, jsonArray: any[]) : unknown[] {
     const fined = query.toLocaleLowerCase();
     const parsedData = parser(jsonArray);
     const results = recursiveSearch(fined, parsedData);
-    const result = results.map((result) =>  jsonArray[result.index]);
+    const result = results.map((result) =>  JSON.parse(jsonArray[result.index]));
     return result;
 }
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -13,7 +13,8 @@ describe("Search function", () => {
             }
         ];
 
-        const results  = search(query, jsonArray.map((o) => JSON.stringify(o)));
+        const results = search(query, jsonArray.map((o) => JSON.stringify(o)));
+        console.log(JSON.stringify(results))
         expect(results.length).toEqual(2);
     });
 
@@ -28,7 +29,8 @@ describe("Search function", () => {
             }
         ];
 
-        const results  = search(query, jsonArray.map((o) => JSON.stringify(o)));
+        const results = search(query, jsonArray.map((o) => JSON.stringify(o)));
+
         expect(results.length).toEqual(0);
     });
 


### PR DESCRIPTION
What's your PL mainly for ? (check one)
* [x] Bug

before, the return was an array of quoted objects, now we're return  an array of JSON objects, 
so that the input  can be the of the same type as the output.
