### PR TITLE
bugfix: added install job in  npm-publish.yml script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - run: npm install
       - run: npm run test
       - run: npm run build
 


### PR DESCRIPTION
* [x] Bug
the npm publish could not run because, npm packages were not being installed on the runner
